### PR TITLE
Add lots of needed gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,17 @@
 source "https://rubygems.org"
 
-gem "sinatra", "~> 2.1"
+gem "sinatra", "~> 3.0"
 
-gem "rack-test", "~> 1.1", group: :test
+gem "rack-test", "~> 2.1", group: :test
 
+gem 'rubocop'
+
+gem 'pry'
+
+gem 'puma'
+
+gem 'ostruct'
+
+gem 'logger'
+
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,90 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.1.1)
+    ast (2.4.3)
+    base64 (0.3.0)
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    method_source (1.1.0)
+    mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.3)
-    rack-protection (2.1.0)
-      rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    nio4r (2.7.4)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    puma (6.6.1)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (2.2.17)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
+    regexp_parser (2.11.2)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.5)
+    rubocop (1.80.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.1.0)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
       tilt (~> 2.0)
-    tilt (2.0.10)
+    tilt (2.6.1)
+    unicode-display_width (3.1.5)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
-  universal-darwin-20
+  arm64-darwin-24
+  ruby
 
 DEPENDENCIES
-  rack-test (~> 1.1)
-  sinatra (~> 2.1)
+  logger
+  ostruct
+  pry
+  puma
+  rack-test (~> 2.1)
+  rspec
+  rubocop
+  sinatra (~> 3.0)
 
 BUNDLED WITH
-   2.2.23
+   2.7.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,5 @@ end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.order = 'default'
+  config.order = 'defined'
 end


### PR DESCRIPTION
This pull request updates dependencies and development tooling in the project, primarily by upgrading core libraries and adding several gems to streamline development and testing. It also makes a small change to the RSpec configuration for more predictable test execution order.

Dependency updates:

* Upgraded `sinatra` to version `~> 3.0` and `rack-test` to `~> 2.1` in the `Gemfile` to ensure compatibility with newer features and security fixes.

Development and testing tooling:

* Added several gems to the `Gemfile` for development and testing, including `rubocop` (linting), `pry` (debugging), `puma` (web server), `ostruct`, `logger`, and `rspec` (testing framework).

Test configuration:

* Changed RSpec test ordering from `'default'` to `'defined'` in `spec/spec_helper.rb` for more predictable and consistent test runs.